### PR TITLE
Add Grains and SqueakyClean solutions and functions

### DIFF
--- a/Function/DartsFunction.cs
+++ b/Function/DartsFunction.cs
@@ -5,6 +5,7 @@ using Exercism.Solution;
 using Microsoft.Azure.Functions.Worker;
 using Microsoft.Azure.Functions.Worker.Http;
 using Microsoft.Extensions.Logging;
+using Microsoft.Net.Http.Headers;
 
 namespace Exercism.Function;
 
@@ -32,7 +33,7 @@ public class DartsFunction
         var response = req.CreateResponse(HttpStatusCode.OK);
         var result = JsonSerializer.Serialize(new { score });
 
-        response.Headers.Add("Content-Type", MediaTypeNames.Application.Json);
+        response.Headers.Add(HeaderNames.ContentType, MediaTypeNames.Application.Json);
         await response.WriteStringAsync(result);
 
         return response;

--- a/Function/GrainsFunction.cs
+++ b/Function/GrainsFunction.cs
@@ -1,0 +1,43 @@
+using System.Net;
+using System.Net.Mime;
+using System.Text.Json;
+using Exercism.Solution;
+using Microsoft.Azure.Functions.Worker;
+using Microsoft.Azure.Functions.Worker.Http;
+using Microsoft.Extensions.Logging;
+
+namespace Exercism.Function;
+
+public class GrainsFunction
+{
+    [Function("grains")]
+    public static async Task<HttpResponseData> Run(
+        [HttpTrigger(AuthorizationLevel.Anonymous, "get")]
+        HttpRequestData req,
+        FunctionContext executionContext)
+    {
+        var logger = executionContext.GetLogger("GrainsFunction");
+        logger.LogInformation("C# HTTP trigger function processed a request.");
+
+        var squareString = req.Query["square"];
+        var response = req.CreateResponse(HttpStatusCode.OK);
+        response.Headers.Add("Content-Type", MediaTypeNames.Application.Json);
+
+        if (string.IsNullOrEmpty(squareString))
+        {
+            await response.WriteStringAsync(JsonSerializer.Serialize(new { total = Grains.Total() }));
+            return response;
+        }
+
+        if (!int.TryParse(squareString, out var square))
+        {
+            var errorResponse = req.CreateResponse(HttpStatusCode.BadRequest);
+            await errorResponse.WriteStringAsync("Invalid input: Please provide valid square number.");
+            return errorResponse;
+        }
+
+        var result = JsonSerializer.Serialize(new { grains = Grains.Square(square) });
+        await response.WriteStringAsync(result);
+        return response;
+    }
+}

--- a/Function/SpaceAgeFunction.cs
+++ b/Function/SpaceAgeFunction.cs
@@ -5,6 +5,7 @@ using Exercism.Solution;
 using Microsoft.Azure.Functions.Worker;
 using Microsoft.Azure.Functions.Worker.Http;
 using Microsoft.Extensions.Logging;
+using Microsoft.Net.Http.Headers;
 
 namespace Exercism.Function;
 
@@ -55,7 +56,7 @@ public class SpaceAgeFunction(ILogger<SpaceAgeFunction> logger)
             _ => new { error = "not a planet" }
         };
 
-        response.Headers.Add("Content-Type", MediaTypeNames.Application.Json);
+        response.Headers.Add(HeaderNames.ContentType, MediaTypeNames.Application.Json);
         await response.WriteStringAsync(JsonSerializer.Serialize(result));
         return response;
     }

--- a/Function/SqueakyCleanFunction.cs
+++ b/Function/SqueakyCleanFunction.cs
@@ -1,0 +1,57 @@
+using System.Net;
+using System.Text.Json;
+using Exercism.Solution;
+using Microsoft.Azure.Functions.Worker;
+using Microsoft.Azure.Functions.Worker.Http;
+using Microsoft.Extensions.Logging;
+using Microsoft.Net.Http.Headers;
+
+namespace Exercism.Function;
+
+public class SqueakyCleanFunction
+{
+    [Function("squeaky-clean")]
+    public async Task<HttpResponseData> Run(
+        [HttpTrigger(AuthorizationLevel.Anonymous, "get", "post")]
+        HttpRequestData req,
+        FunctionContext executionContext)
+    {
+        var logger = executionContext.GetLogger("SqueakyCleanFunction");
+        logger.LogInformation("C# HTTP trigger function processed a request.");
+
+        string? identifier;
+
+        if (req.Method == HttpMethod.Get.ToString())
+        {
+            identifier = req.Query["identifier"];
+        }
+        else
+        {
+            var requestBody = await req.ReadAsStringAsync();
+            var data = JsonSerializer.Deserialize<IdentifierInput>(requestBody);
+            identifier = data?.Identifier;
+        }
+
+        if (string.IsNullOrEmpty(identifier))
+        {
+            var errorResponse = req.CreateResponse(HttpStatusCode.BadRequest);
+            await errorResponse.WriteStringAsync("Please provide an identifier.");
+            return errorResponse;
+        }
+
+        var cleanedIdentifier = Identifier.Clean(identifier);
+        var response = req.CreateResponse(HttpStatusCode.OK);
+
+        var result = JsonSerializer.Serialize(new { cleanedIdentifier });
+
+        response.Headers.Add(HeaderNames.ContentType, "application/json; charset=utf-8");
+        await response.WriteStringAsync(result);
+
+        return response;
+    }
+
+    private class IdentifierInput
+    {
+        public string Identifier { get; set; }
+    }
+}

--- a/Solution/Grains.cs
+++ b/Solution/Grains.cs
@@ -1,0 +1,20 @@
+namespace Exercism.Solution;
+
+public static class Grains
+{
+    private const int MinSquareNumber = 1;
+    private const int MaxSquareNumber = 64;
+
+    public static ulong Square(int n)
+    {
+        return n is < MinSquareNumber or > MaxSquareNumber
+            ? throw new ArgumentOutOfRangeException(nameof(n),
+                $"Input must be within the range of {MinSquareNumber} and {MaxSquareNumber} inclusive.")
+            : 1ul << --n;
+    }
+
+    public static ulong Total()
+    {
+        return ~0ul;
+    }
+}

--- a/Solution/SqueakyClean.cs
+++ b/Solution/SqueakyClean.cs
@@ -1,0 +1,28 @@
+namespace Exercism.Solution;
+
+using System.Text;
+
+public static class Identifier
+{
+    public static string Clean(string identifier)
+    {
+        var result = new StringBuilder();
+        var isAfterDash = false;
+
+        foreach (var symbol in identifier)
+        {   
+            result.Append(symbol switch
+            {
+                >= 'α' and <= 'ω' => default,
+                _ when isAfterDash => char.ToUpperInvariant(symbol),
+                _ when char.IsWhiteSpace(symbol) => '_',
+                _ when char.IsControl(symbol) => "CTRL",
+                _ when char.IsLetter(symbol) => symbol,
+                _ => default
+            });
+            isAfterDash = symbol.Equals('-');
+        }
+
+        return result.ToString();
+    }
+}


### PR DESCRIPTION
Include implementations for two new solutions, Grains and SqueakyClean. These solutions come with their corresponding functions. Also, refactor the SpaceAgeFunction and DartsFunction replacing 'Content-Type' with HeaderNames.ContentType to maintain consistency in how headers are added.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a function to calculate grains on a chessboard, either total or on a specific square, with JSON responses.
	- Implemented a function to clean identifiers with support for both GET and POST requests, returning the cleaned identifier in JSON.
- **Refactor**
	- Updated the way `Content-Type` header is added to responses in certain functions for improved standards compliance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->