### PR TITLE
Add Pythagorean triplet function and improve error handling

### DIFF
--- a/Function/PigLatinFunction.cs
+++ b/Function/PigLatinFunction.cs
@@ -23,7 +23,10 @@ public class PigLatinFunction
         string sentence = data?.sentence;
         logger.LogInformation("Processing sentence:" + sentence);
 
-        if (sentence == null) return new BadRequestObjectResult("Please pass a sentence in the request body json");
+        if (sentence == null)
+        {
+            return new BadRequestObjectResult("Please pass a sentence in the request body json");
+        }
 
         var pigLatin = PigLatin.Translate(sentence);
         logger.LogInformation($"Translated sentence to Pig Latin: {pigLatin}");

--- a/Function/PythagoreanTripletFunction.cs
+++ b/Function/PythagoreanTripletFunction.cs
@@ -1,0 +1,36 @@
+using Exercism.Solution;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Azure.Functions.Worker;
+using Microsoft.Azure.Functions.Worker.Http;
+using Microsoft.Extensions.Logging;
+
+namespace Exercism.Function;
+
+public class PythagoreanTripletFunction
+{
+    [Function("pythagorean-triplet")]
+    public IActionResult Run(
+        [HttpTrigger(AuthorizationLevel.Anonymous, "get", Route = "pythagorean-triplet/{sum:int?}")]
+        HttpRequestData req,
+        int sum,
+        FunctionContext executionContext)
+    {
+        var logger = executionContext.GetLogger("PythagoreanTripletFunction");
+        logger.LogInformation("Processing request...");
+
+        if (sum <= 0)
+        {
+            logger.LogWarning("Invalid sum provided in request.");
+            return new BadRequestObjectResult(new { error = "Please provide a valid sum." });
+        }
+
+        var triplets = PythagoreanTriplet.TripletsWithSum(sum)
+            .Select(t => new Triplet(t.a, t.b, t.c))
+            .ToList();
+        logger.LogInformation($"Found {triplets.Count} triplets with sum {sum}");
+
+        return new OkObjectResult(new { sum, triplets });
+    }
+}
+
+public record Triplet(int A, int B, int C);

--- a/Solution/PythagoreanTriplet.cs
+++ b/Solution/PythagoreanTriplet.cs
@@ -1,0 +1,13 @@
+namespace Exercism.Solution;
+
+public static class PythagoreanTriplet
+{
+    public static IEnumerable<(int a, int b, int c)> TripletsWithSum(int sum)
+    {
+        return from a in Enumerable.Range(2, sum / 3 - 2)
+            from b in Enumerable.Range(a + 1, (sum - 3 * a) / 2)
+            let c = sum - a - b
+            where a * a + b * b == c * c
+            select (a, b, c);
+    }
+}

--- a/test-functions.http
+++ b/test-functions.http
@@ -33,3 +33,7 @@ POST /api/piglatin
 ?? body pigLatin isString
 ?? body pigLatin endsWith ay
 ?? body pigLatin.length equals {{pangram.sentence.length + "ay".length}}
+
+### Pythagorean Triplet
+GET /api/pythagorean-triplet/{{$random.integer(12, 1000)}}
+


### PR DESCRIPTION
Added a new function to calculate Pythagorean triplets given a sum. This function runs when a GET request is sent to /api/pythagorean-triplet/{sum}. Also improved the error handling in the existing PigLatinFunction by splitting a long line of code into multiple lines to enhance readability and maintainability.